### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
         id: check
         run: |
           source ci/env.sh
-          echo "::set-output name=tag::$CI_TAG"
+          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"
-          echo "::set-output name=channel::$CHANNEL"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
 
       - name: Get specific changed files
         id: changed-files-specific

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           echo "tag: ${{ steps.check.outputs.tag }}"
           echo "channel: ${{ steps.check.outputs.channel }}"
           echo "any changes: ${{ steps.changed-files-specific.outputs.any_changed }}"
-          echo "::set-output name=need_to_build::${{
+          echo "need_to_build=${{
             steps.check.outputs.tag != ''
             ||
             (
@@ -51,7 +51,7 @@ jobs:
               &&
               steps.changed-files-specific.outputs.any_changed != ''
             )
-          }}"
+          }}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Setup Node

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
         id: check
         run: |
           source ci/env.sh
-          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$CI_TAG" >> "$GITHUB_OUTPUT"
           eval "$(ci/channel-info.sh)"
-          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
 
       - name: Get specific changed files
         id: changed-files-specific
@@ -51,7 +51,7 @@ jobs:
               &&
               steps.changed-files-specific.outputs.any_changed != ''
             )
-          }}" >> $GITHUB_OUTPUT
+          }}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Setup Node

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,9 +51,9 @@ jobs:
           export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
           choco install protoc
           source /tmp/env.sh
-          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$CI_TAG" >> "$GITHUB_OUTPUT"
           eval "$(ci/channel-info.sh)"
-          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,9 +51,9 @@ jobs:
           export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
           choco install protoc
           source /tmp/env.sh
-          echo "::set-output name=tag::$CI_TAG"
+          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"
-          echo "::set-output name=channel::$CHANNEL"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


